### PR TITLE
refactor to allowKeywordExtractingHandler to read from prompt txt

### DIFF
--- a/App/kernel-memory/service/Abstractions/Constants.cs
+++ b/App/kernel-memory/service/Abstractions/Constants.cs
@@ -163,4 +163,5 @@ public static class Constants
     // Standard prompt names
     public const string PromptNamesSummarize = "summarize";
     public const string PromptNamesAnswerWithFacts = "answer-with-facts";
+    public const string PromptNamesExtractKeywords = "extract-keywords";
 }

--- a/App/kernel-memory/service/Core/Core.csproj
+++ b/App/kernel-memory/service/Core/Core.csproj
@@ -42,6 +42,7 @@
     <ItemGroup>
         <EmbeddedResource Include="Prompts\summarize.txt" />
         <EmbeddedResource Include="Prompts\answer-with-facts.txt" />
+        <EmbeddedResource Include="Prompts\extract-keywords.txt" />
     </ItemGroup>
 
     <ItemGroup>

--- a/App/kernel-memory/service/Core/Handlers/KeywordExtractingHandler.cs
+++ b/App/kernel-memory/service/Core/Handlers/KeywordExtractingHandler.cs
@@ -11,6 +11,7 @@ using Microsoft.KernelMemory.Pipeline;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using static Microsoft.KernelMemory.Pipeline.DataPipeline;
+using Microsoft.KernelMemory.Prompts;
 
 namespace Microsoft.KernelMemory.Handlers;
 
@@ -21,11 +22,13 @@ public sealed class KeywordExtractingHandler : IPipelineStepHandler
     private readonly IPipelineOrchestrator _orchestrator;
     private readonly Kernel _kernel;
     private readonly KernelMemoryConfig? _config = null;
+    private readonly string _extractKeywordPrompt;
 
     public KeywordExtractingHandler(
         string stepName,
         IPipelineOrchestrator orchestrator,
         KernelMemoryConfig config = null,
+        IPromptProvider? promptProvider = null,
         ILoggerFactory? loggerFactory = null
         )
     {
@@ -33,6 +36,10 @@ public sealed class KeywordExtractingHandler : IPipelineStepHandler
         this._log = (loggerFactory ?? DefaultLogger.Factory).CreateLogger<KeywordExtractingHandler>();
         this._orchestrator = orchestrator;
         this._config = config;
+
+        promptProvider ??= new EmbeddedPromptProvider();
+
+        this._extractKeywordPrompt = promptProvider.ReadPrompt(Constants.PromptNamesExtractKeywords);
 
         //init Semantic Kernel
         this._kernel = Kernel.CreateBuilder()
@@ -79,30 +86,7 @@ public sealed class KeywordExtractingHandler : IPipelineStepHandler
                     var chat = this._kernel.GetRequiredService<IChatCompletionService>();
                     var chatHistory = new ChatHistory();
 
-                    var systemMessage = """
-                        You are an assistant to analyze Content and Extract Tags by Content.
-                        [EXTRACT TAGS RULES]
-                        IT SHOULD BE A LIST OF DICTIONARIES WITH CATEGORY AND TAGS
-                        TAGS SHOULD BE CATEGORY SPECIFIC
-                        TAGS SHOULD BE A LIST OF STRINGS
-                        TAGS COUNT CAN BE UP TO 10 UNDER A CATEGORY
-                        CATEGORY COUNT CAN BE UP TO 10
-                        DON'T ADD ANY MARKDOWN EXPRESSION IN YOUR RESPONSE
-                        [END RULES]
-
-                        [EXAMPLE]
-                        [
-                            {
-                                [category1": ["tag1", "tag2", "tag3"]
-                            },
-                            {
-                                "category2": ["tag1", "tag2", "tag3"]
-                            }
-                        ]
-                        [END EXAMPLE]
-                        """;
-
-                    chatHistory.AddSystemMessage(systemMessage);
+                    chatHistory.AddSystemMessage(this._extractKeywordPrompt);
                     chatHistory.AddUserMessage($"Extract tags from this content : {extactedFileContent} \n The format should be Json but Markdown expression.");
 
                     var executionParam = new PromptExecutionSettings()


### PR DESCRIPTION
#22 
This pull request introduces a new feature for extracting keywords from content. The changes include adding a new prompt for keyword extraction, updating project files to include the new prompt, and modifying the `KeywordExtractingHandler` class to use the new prompt.

Additions to prompt constants and resources:

* [`App/kernel-memory/service/Abstractions/Constants.cs`](diffhunk://#diff-b0e3ee4d1190e8411c98b1fa8a400a14f184dba51620de7929334989c08bb552R166): Added a new constant `PromptNamesExtractKeywords` for the keyword extraction prompt.
* [`App/kernel-memory/service/Core/Core.csproj`](diffhunk://#diff-53b652c5b89484049ffe79250831e573b475661d31432a94b5893226ec13e34fR45): Included the new `extract-keywords.txt` file as an embedded resource.

Modifications to `KeywordExtractingHandler`:

* [`App/kernel-memory/service/Core/Handlers/KeywordExtractingHandler.cs`](diffhunk://#diff-b3a2a25740a5a3800d68c7030eaaee478efd02bad26a4ef2ec704185647af7ebR14): Imported `Microsoft.KernelMemory.Prompts` to access prompt-related functionality.
* [`App/kernel-memory/service/Core/Handlers/KeywordExtractingHandler.cs`](diffhunk://#diff-b3a2a25740a5a3800d68c7030eaaee478efd02bad26a4ef2ec704185647af7ebR25-R31): Added a new field `_extractKeywordPrompt` and updated the constructor to initialize this field using a prompt provider. [[1]](diffhunk://#diff-b3a2a25740a5a3800d68c7030eaaee478efd02bad26a4ef2ec704185647af7ebR25-R31) [[2]](diffhunk://#diff-b3a2a25740a5a3800d68c7030eaaee478efd02bad26a4ef2ec704185647af7ebR40-R43)
* [`App/kernel-memory/service/Core/Handlers/KeywordExtractingHandler.cs`](diffhunk://#diff-b3a2a25740a5a3800d68c7030eaaee478efd02bad26a4ef2ec704185647af7ebL82-R89): Replaced the hardcoded system message with the new keyword extraction prompt.