### PR TITLE
fix: added colon in  dockerfile to fix the deployment issue

### DIFF
--- a/App/kernel-memory/Dockerfile
+++ b/App/kernel-memory/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     #Debian: useradd --create-home --user-group $USER --shell /bin/bash && \
     adduser -D -h /app -s /bin/sh $USER && \
     # Allow user to access the build
-    chown -R $USER.$USER /app
+    chown -R $USER:$USER /app
 
 COPY --from=build --chown=km:km --chmod=0550 /app/publish .
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Remove the dot and replace it with a colon in the `Dockerfile` to fix the deployment issue.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## Golden Path Validation: NA
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [X] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* Remove the dot and replace it with a colon in the `Dockerfile` to fix the deployment issue. Now working fine.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
