### PR TITLE
fix: Downgrade Microsoft.SemanticKernel.Abstractions to resolve image file upload issue

### DIFF
--- a/App/kernel-memory/Directory.Packages.props
+++ b/App/kernel-memory/Directory.Packages.props
@@ -66,7 +66,7 @@
   <!-- Semantic Kernel -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.15.1" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.31.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.15.1" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.15.1" />
   </ItemGroup>
   <!-- Documentation -->


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The image file upload was failing due to compatibility issues with the latest version of Microsoft.SemanticKernel.Abstractions.
* Downgraded the package to ensure proper handling of image file uploads.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [x] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid:

- Verify that image file uploads (PNG, JPG, and other supported formats) are processed successfully.
- Ensure there are no new dependency conflicts or regressions in other functionalities.
- Validate that all related services continue working as expected after the downgrade.