### PR TITLE
fix: Updated to GA of Document Intelligence - beta does not work against all Azure regions

### DIFF
--- a/App/kernel-memory/Directory.Packages.props
+++ b/App/kernel-memory/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
     <PackageVersion Include="AWSSDK.S3" Version="3.7.310.4" />
-    <PackageVersion Include="Azure.AI.DocumentIntelligence" Version="1.0.0-beta.2" />
+    <PackageVersion Include="Azure.AI.DocumentIntelligence" Version="1.0.0" />
     <PackageVersion Include="Azure.AI.FormRecognizer" Version="4.1.0" />
     <PackageVersion Include="Azure.Core" Version="1.42.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />

--- a/App/kernel-memory/service/Core/DataFormats/Pdf/PdfMarkdownDecoder.cs
+++ b/App/kernel-memory/service/Core/DataFormats/Pdf/PdfMarkdownDecoder.cs
@@ -38,7 +38,10 @@ public sealed class PdfMarkdownDecoder(KernelMemoryConfig config, ILoggerFactory
 
     public async Task<FileContent> DecodeAsync(BinaryData data, CancellationToken cancellationToken = default)
     {
-        var content = new AnalyzeDocumentContent() { Base64Source = data };
+        var analyzeDocumentOptions = new AnalyzeDocumentOptions("prebuilt-layout", data)
+        {
+            OutputContentFormat = DocumentContentFormat.Markdown
+        };
 
         //this invocation should be blocking during process
         DocumentIntelligenceClientOptions options = new()
@@ -49,7 +52,7 @@ public sealed class PdfMarkdownDecoder(KernelMemoryConfig config, ILoggerFactory
         this._client = new DocumentIntelligenceClient(new Uri(this._endpoint), new AzureKeyCredential(this._apiKey), options);
 
         Operation<AnalyzeResult> operation = null;
-        operation = await this._client.AnalyzeDocumentAsync(WaitUntil.Completed, "prebuilt-layout", content, outputContentFormat: ContentFormat.Markdown, cancellationToken: cancellationToken).ConfigureAwait(false);
+        operation = await this._client.AnalyzeDocumentAsync(WaitUntil.Completed, analyzeDocumentOptions, cancellationToken).ConfigureAwait(false);
 
         AnalyzeResult result = operation.Value;
 


### PR DESCRIPTION
… regions

## Purpose
* Switch to the GA version of Azure.AI.DocumentIntelligence. The current beta version is locked to an api-version that only works in a couple of Azure regions. For example, returns a 404 when Document Intelligence is deployed to Australia East.

## Does this introduce a breaking change?
- [ ] Yes
- [x ] No

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

https://learn.microsoft.com/en-us/answers/questions/1514842/document-intelligence-ai-returns-404
