### PR TITLE
fix: "Clear All" Button Not Resetting Search Box Text

### DIFF
--- a/App/frontend-app/src/pages/home/home.tsx
+++ b/App/frontend-app/src/pages/home/home.tsx
@@ -54,7 +54,7 @@ export function Home({ isSearchResultsPage }: HomeProps) {
     const navigate = useNavigate();
     const location = useLocation();
     const [reset, setReset] = useState(false);  // State to trigger reset
-
+    const [clearSearchBox, setClearSearchBox] = useState(false);
     const [clearAllTriggered, setClearAllTriggered] = useState(false);
     const [clearFilters, setClearFilters] = useState(false);
     const [resetSearchBox, setResetSearchBox] = useState(false);
@@ -141,15 +141,16 @@ export function Home({ isSearchResultsPage }: HomeProps) {
 
     useEffect(() => {
         if (searchBoxRef.current) {
-            if (resetSearchBox) {
-                
+            if (resetSearchBox && clearSearchBox) {
                 searchBoxRef.current.reset();
                 setResetSearchBox(false); // Reset the trigger
             } else {
-                const urlQuery = searchParams.get("q");
-                if (urlQuery) {
-                    const decodedQuery = decodeURIComponent(urlQuery);
-                    searchBoxRef.current.setValue(decodedQuery);
+                if(!clearSearchBox){
+                    const urlQuery = searchParams.get("q");
+                    if (urlQuery) {
+                        const decodedQuery = decodeURIComponent(urlQuery);
+                        searchBoxRef.current.setValue(decodedQuery);
+                    }
                 }
             }
         }
@@ -165,15 +166,24 @@ export function Home({ isSearchResultsPage }: HomeProps) {
                 setSearchParams({}); // Clear all search params when there's no query
             }
         } else {
-            const q = searchParams.get("q");
-            if (q) {
-                setQuery(decodeURIComponent(q)); 
+            if(!clearSearchBox){
+                const q = searchParams.get("q");
+                if (q) {
+                    setQuery(decodeURIComponent(q)); 
+                }
             }
         }
     }, [isSearchResultsPage, query, searchParams, setSearchParams]);
 
+    useEffect(() => {
+        const q = searchParams.get("q");
+        if(!q){
+            setClearSearchBox(false)
+        }
+    },[searchParams])
+    
     function onSearchChanged(searchValue: string): void {
-        if (searchValue) {
+       if (searchValue) {
             setTextValue(searchValue);
         }
         if (searchValue) {
@@ -189,7 +199,7 @@ export function Home({ isSearchResultsPage }: HomeProps) {
             }
         } else {
             setSearchResultDocuments([]);
-            setSearchParams("");
+            setSearchParams({});
             setQuery(searchValue);
         }
     }
@@ -462,6 +472,7 @@ export function Home({ isSearchResultsPage }: HomeProps) {
         setSelectedDocuments([]);
         setClearAllTriggered(true); // Set this flag to true
         setClearFilters(true);
+        setClearSearchBox(true);
         // Call loadDataAsync after clearing
         loadDataAsync();
     }, [/* dependencies */]);


### PR DESCRIPTION
## Purpose
The search term should be cleared from the search box.
All documents should be displayed in the list.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Steps to Reproduce:

- Open the DKM (Document Knowledge Mining) web application.
- Upload multiple documents in the Documents section.
- Enter a search term in the search box—the document list filters based on the searched text.

