### PR TITLE
fix: Text file getting downloaded on click of details button

### DIFF
--- a/App/frontend-app/src/components/documentViewer/documentViewer.tsx
+++ b/App/frontend-app/src/components/documentViewer/documentViewer.tsx
@@ -75,6 +75,7 @@ export function DocDialog(
     const [iframeKey, setIframeKey] = useState(0);
     const [isExpanded, setIsExpanded] = useState(false);
     const [clearedChatFlag, setClearChatFlag] = useState(clearChatFlag);
+    const [iframeSrc, setIframeSrc] = useState<string | undefined>(undefined);
     // const [aiKnowledgeMetadata, setAIKnowledgeMetadata] = useState<Document | null>(null);
 
 
@@ -90,6 +91,24 @@ export function DocDialog(
             setUrlWithSasToken(undefined);
         }
     }, [metadata]); // Only run when metadata changes
+
+    useEffect(() => {
+        if (metadata && metadata.fileName.endsWith(".txt")) {
+            fetch(metadata.document_url)
+                .then((response) => response.text())
+                .then((textContent) => {
+                    const blob = new Blob([textContent], { type: "text/plain" });
+                    const objectURL = URL.createObjectURL(blob);
+                    setIframeSrc(objectURL);
+
+                    // Cleanup the object URL when component unmounts or metadata changes
+                    return () => URL.revokeObjectURL(objectURL);
+                })
+                .catch((error) => console.error("Error fetching text file:", error));
+        } else {
+            setIframeSrc(metadata?.document_url);
+        }
+    }, [metadata]);
     
 
     const downloadFile = () => {
@@ -236,7 +255,7 @@ export function DocDialog(
                                 <IFrameComponent
                                     className="h-[100%]"
                                     metadata={metadata}
-                                    urlWithSasToken={urlWithSasToken}
+                                    urlWithSasToken={iframeSrc}
                                     iframeKey={iframeKey}
                                 />
                             </div>


### PR DESCRIPTION
## Purpose
The pop up should show the content of the file and the file should not get downloaded automatically.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->


## What to Check
- Open the DKM (Document Knowledge Mining) web application.
- Upload .txt file in the Documents section.
- Click on Details button besides the .txt file.

![image](https://github.com/user-attachments/assets/7bdb3325-1aa7-4bde-9852-6b6e4b56e72a)

