### PR TITLE
fix: Chat Input Reset and Send Button Disable Logic in ChatRoom Component

### DIFF
--- a/App/frontend-app/src/components/chat/chatRoom.tsx
+++ b/App/frontend-app/src/components/chat/chatRoom.tsx
@@ -73,6 +73,7 @@ export function ChatRoom({ searchResultDocuments, selectedDocuments, chatWithDoc
     });
     const [referencesForFeedbackForm, setReferencesForFeedbackForm] = useState<Reference[]>([]);
     const [textAreaValue, setTextAreaValue] = useState("");
+    const [textareaKey, setTextareaKey] = useState(0);
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const [allChunkTexts, setAllChunkTexts] = useState<string[]>([]);
 
@@ -568,12 +569,15 @@ export function ChatRoom({ searchResultDocuments, selectedDocuments, chatWithDoc
                         setSelectedDocument([]);
                         setIsLoading(false);
                         setChatSessionId(null);
+                        setTextAreaValue("");
+                        setTextareaKey(prev => prev + 1);
                     }}
                 >
                     {t('components.chat.new-topic')}
                 </Button>
 
                 <Textarea
+                    key={textareaKey}
                     ref={inputRef}
                     value={textAreaValue}
                     className="!ml-4 max-h-48 w-full !max-w-none"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR resolves bugs in the ChatRoom component related to the chat input field

- Ensures the textarea is properly cleared and reset after starting a new topic.
- Disables the send button when the input is empty or the chat is loading, preventing unintended or empty submissions.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid:

- After starting a new topic, confirm the chat input is fully cleared and cannot send empty messages.
- The send button should be disabled when the input is empty or during loading states.
- Ensure a smooth user experience with no regressions in chat operations.
