### PR TITLE
fix: Previously uploaded/failed files still visible after reopening the upload document popup

### DIFF
--- a/App/frontend-app/src/components/uploadButton/uploadButton.tsx
+++ b/App/frontend-app/src/components/uploadButton/uploadButton.tsx
@@ -93,9 +93,22 @@ const UploadDocumentsDialog = () => {
     noKeyboard: true,
   });
 
+  // Add this function to handle dialog close
+  const handleDialogClose = () => {
+    setIsOpen(false);
+    setUploadingFiles([]); // Clear the uploaded files
+    setIsUploading(false); // Reset uploading state
+  };
+
   return (<>
     {isUploadBtnVisible == true ?
-      <Dialog open={isOpen} onOpenChange={(event, data) => setIsOpen(data.open)}>
+      <Dialog open={isOpen} onOpenChange={(event, data) => {
+        if (!data.open) {
+          handleDialogClose();
+        } else {
+          setIsOpen(data.open);
+        }
+      }}>
         <DialogTrigger>
           <Button icon={<ArrowUpload24Regular />} onClick={() => setIsOpen(true)}>
             Upload documents
@@ -108,7 +121,7 @@ const UploadDocumentsDialog = () => {
               <Button
                 icon={<DismissRegular />}
                 appearance="subtle"
-                onClick={() => setIsOpen(false)}
+                onClick={handleDialogClose}
                 style={{ position: "absolute", right: 20, top: 20 }}
               />
             </DialogTitle>


### PR DESCRIPTION
## Purpose
Previously uploaded/failed files still visible after reopening the upload document popup

Bug: https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/20381

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->


screenshot :
![image](https://github.com/user-attachments/assets/f35bc7a9-d83b-45d2-9118-239f17066dc0)


without refresh the page
![image](https://github.com/user-attachments/assets/28bbfd42-4328-4960-b4f5-87c43e6bdedb)

