### PR TITLE
feat: Added templateName tag on rg

### DIFF
--- a/Deployment/resourcedeployment.ps1
+++ b/Deployment/resourcedeployment.ps1
@@ -230,15 +230,16 @@ function DeployAzureResources([string]$location, [string]$modelLocation) {
             Write-Host "Generated Resource Group Name: $resourceGroupName"
 
             Write-Host "No RG provided. Creating new RG: $resourceGroupName" -ForegroundColor Yellow
-            az group create --name $resourceGroupName --location $location --tags EnvironmentName=$environmentName | Out-Null
+            az group create --name $resourceGroupName --location $location --tags EnvironmentName=$environmentName TemplateName="DKM" | Out-Null
         }
         else {
             $exists = az group exists --name $resourceGroupName | ConvertFrom-Json
             if (-not $exists) {
                 Write-Host "Specified RG does not exist. Creating RG: $resourceGroupName" -ForegroundColor Yellow
-                az group create --name $resourceGroupName --location $location --tags EnvironmentName=$environmentName | Out-Null
+                az group create --name $resourceGroupName --location $location --tags EnvironmentName=$environmentName TemplateName="DKM" | Out-Null
             }
             else {
+                az group update --name $resourceGroupName --set tags.EnvironmentName=$environmentName tags.TemplateName="DKM" | Out-Null
                 Write-Host "Using existing RG: $resourceGroupName" -ForegroundColor Green
             }
         }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This pull request updates the resource group management logic in the `DeployAzureResources` function within the `Deployment/resourcedeployment.ps1` script. The changes ensure that a new tag, `TemplateName="DKM"`, is consistently applied to resource groups during creation or update.

### Resource group tagging updates:
* Added the `TemplateName="DKM"` tag to resource group creation commands to ensure all newly created resource groups include this tag.
* Introduced a resource group update command to apply the `TemplateName="DKM"` and `EnvironmentName` tags to existing resource groups when they are reused.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
