### PR TITLE
fix: Update Bicep file path for cross-platform compatibility in deployment script

### DIFF
--- a/Deployment/resourcedeployment.ps1
+++ b/Deployment/resourcedeployment.ps1
@@ -246,7 +246,7 @@ function DeployAzureResources([string]$location, [string]$modelLocation) {
 
         # Perform a what-if deployment to preview changes
         Write-Host "Evaluating Deployment resource availabilities to preview changes..." -ForegroundColor Yellow
-        $whatIfResult = az deployment group what-if --resource-group $resourceGroupName --template-file .\main.bicep --name $deploymentName --parameters modeldatacenter=$modelLocation location=$location environmentName=$environmentName
+        $whatIfResult = az deployment group what-if --resource-group $resourceGroupName --template-file "./main.bicep" --name $deploymentName --parameters modeldatacenter=$modelLocation location=$location environmentName=$environmentName
 
         if ($LASTEXITCODE -ne 0) {
             Write-Host "There might be something wrong with your deployment." -ForegroundColor Red
@@ -257,7 +257,7 @@ function DeployAzureResources([string]$location, [string]$modelLocation) {
         # Proceed with the actual deployment
         Write-Host "Proceeding with Deployment..." -ForegroundColor Yellow
         Write-Host "Resource Group Name: $resourceGroupName" -ForegroundColor Yellow
-        $deploymentResult = az deployment group create --resource-group $resourceGroupName --template-file .\main.bicep --name $deploymentName --parameters modeldatacenter=$modelLocation location=$location environmentName=$environmentName
+        $deploymentResult = az deployment group create --resource-group $resourceGroupName --template-file "./main.bicep" --name $deploymentName --parameters modeldatacenter=$modelLocation location=$location environmentName=$environmentName
         # Check if deploymentResult is valid        
         ValidateVariableIsNullOrEmpty -variableValue $deploymentResult -variableName "Deployment Result"  
         if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This pull request makes a minor update to the deployment script by standardizing the path format for the `main.bicep` template file. The change replaces backslashes with forward slashes in the `--template-file` argument for both the what-if and actual deployment commands, improving cross-platform compatibility.

- Deployment script improvements:
  * Updated the `--template-file` argument in both the what-if (`az deployment group what-if`) and deployment (`az deployment group create`) commands to use `"./main.bicep"` instead of `.\main.bicep`, ensuring consistent path formatting. [[1]](diffhunk://#diff-8efa90352de03fa0a511a5c08f49e4c1ba0224d16bf6facaf7c7ba90524edddbL249-R249) [[2]](diffhunk://#diff-8efa90352de03fa0a511a5c08f49e4c1ba0224d16bf6facaf7c7ba90524edddbL260-R260)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid:

- Bicep file path uses / instead of \
- Script works on Windows, macOS, and Linux
- No unrelated changes included

