### PR TITLE
fix: Psl addcreatedbyparaminyml

### DIFF
--- a/Deployment/main.bicep
+++ b/Deployment/main.bicep
@@ -23,14 +23,15 @@ var resourceGroupLocation = resourceGroup().location
 // Load the abbrevations file required to name the azure resources.
 var abbrs = loadJsonContent('./abbreviations.json')
 
-var deployerInfo = deployer()
+@description('Optional created by user name')
+param createdBy string //= empty(deployer().userPrincipalName) ? '' : split(deployer().userPrincipalName, '@')[0]
 
 resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
   name: 'default'
   properties: {
     tags: {
       TemplateName: 'DKM'
-      CreatedBy: split(deployerInfo.userPrincipalName, '@')[0] 
+      CreatedBy: createdBy
     }
   }
 }
@@ -212,4 +213,6 @@ output gs_containerregistry_endpoint string = gs_containerregistry.outputs.acrEn
 
 //return resourcegroup resource ID
 output gs_resourcegroup_id string = resourceGroup().id
+
+output createdByOutput string = createdBy
 

--- a/Deployment/resourcedeployment.ps1
+++ b/Deployment/resourcedeployment.ps1
@@ -184,7 +184,8 @@ function LoginAzure([string]$subscriptionID) {
             Write-Host "Logged in to Azure with tenant ID '$tenantId' successfully." -ForegroundColor Green
         }
         Write-Host "manual deployment mode"
-        $createdBy = $email
+        $createdBy = $email.Split('@')[0]
+        Write-Host "CreatedBy user is $createdBy"
     }
     az account set --subscription $subscriptionID
     Write-Host "Switched subscription to '$subscriptionID' `r`n" -ForegroundColor Yellow  


### PR DESCRIPTION
## Purpose
This pull request adds support for tracking and tagging Azure resource deployments with the user who initiated the deployment, improving traceability and auditability. The changes ensure that a `createdBy` tag is consistently set during resource group creation, updates, and deployments, and that this information is passed through from the deployment scripts to the Bicep templates.

Tagging and parameterization improvements:

* Added a `createdBy` parameter to `main.bicep`, allowing the user name of the deployer to be passed in and used as a resource group tag, replacing the previous hardcoded extraction from the deployer principal name.
* Updated resource group creation, update, and deployment commands in `resourcedeployment.ps1` to set the `createdBy` tag using the provided email or pipeline context, ensuring consistent tagging for all resource groups. [[1]](diffhunk://#diff-8efa90352de03fa0a511a5c08f49e4c1ba0224d16bf6facaf7c7ba90524edddbR195-R201) [[2]](diffhunk://#diff-8efa90352de03fa0a511a5c08f49e4c1ba0224d16bf6facaf7c7ba90524edddbL233-R257) [[3]](diffhunk://#diff-8efa90352de03fa0a511a5c08f49e4c1ba0224d16bf6facaf7c7ba90524edddbL260-R268)
* Added an output for `createdBy` in `main.bicep` to expose the value used during deployment.

Deployment script enhancements:

* Modified the deployment PowerShell script to determine the `createdBy` value based on whether the deployment is running in CI or interactively, improving automation and user attribution.

Minor script and parameter fixes:

* Added a missing comma in the PowerShell function parameter list and fixed formatting in the Azure login command. [[1]](diffhunk://#diff-8efa90352de03fa0a511a5c08f49e4c1ba0224d16bf6facaf7c7ba90524edddbR83) [[2]](diffhunk://#diff-8efa90352de03fa0a511a5c08f49e4c1ba0224d16bf6facaf7c7ba90524edddbL172-R173)
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
