### PR TITLE
fix: added more timeout and updated avm module vesion of search service

### DIFF
--- a/Deployment/send-filestoendpoint.psm1
+++ b/Deployment/send-filestoendpoint.psm1
@@ -20,8 +20,8 @@ function Send-FilesToEndpoint {
     # Get all files in the Data folder
     $files = Get-ChildItem -Path $DataFolderPath -File
 
-    # Create HttpClient with timeout
-    $timeout = 300000 # Timeout in milliseconds (e.g., 300000 ms = 300 seconds)
+    # Create HttpClient with timeout with 20minutes
+    $timeout = 1200000 # Timeout in milliseconds (e.g., 1200000 ms = 1200 seconds)
     $httpClient = [System.Net.Http.HttpClient]::new()
     $httpClient.Timeout = [TimeSpan]::FromMilliseconds($timeout)
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -657,7 +657,7 @@ module avmStorageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
 
 // ========== AI Foundry: AI Search ========== //
 var aiSearchName = 'srch-${solutionSuffix}'
-module avmSearchSearchServices 'br/public:avm/res/search/search-service:0.9.1' = {
+module avmSearchSearchServices 'br/public:avm/res/search/search-service:0.11.1' = {
   name: take('avm.res.cognitive-search-services.${aiSearchName}', 64)
   params: {
     name: aiSearchName


### PR DESCRIPTION
## Purpose
This pull request contains two targeted updates: one increases the timeout for file uploads in a deployment script, and the other updates the version of the Azure Search Service module used in the infrastructure configuration.

**Deployment script improvement:**

* Increased the HTTP client timeout in the `Send-FilesToEndpoint` function from 5 minutes (300,000 ms) to 20 minutes (1,200,000 ms) in `send-filestoendpoint.psm1`, allowing more time for large file uploads to complete.

**Infrastructure module update:**

* Upgraded the Azure Search Service module in `main.bicep` from version `0.9.1` to `0.11.1`, which may include new features, bug fixes, or performance improvements.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->
