### PR TITLE
ci: add continue-on-error to post-deployment step for CI 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -347,6 +347,7 @@ jobs:
           fi
 
       - name: Run Post Deployment Script
+        continue-on-error: true
         shell: pwsh
         run: |
           Write-Host "Running post deployment script to upload files..."
@@ -357,13 +358,11 @@ jobs:
             if ($LASTEXITCODE -eq $null -or $LASTEXITCODE -eq 0) {
               Write-Host "✅ Post deployment script completed successfully."
             } else {
-              Write-Host "❌ Post deployment script failed with exit code: $LASTEXITCODE"
-              exit 1
+              Write-Host "⚠️ Post deployment script failed with exit code: $LASTEXITCODE, but pipeline will continue."
             }
           }
           catch {
-            Write-Host "❌ Post deployment script failed with error: $($_.Exception.Message)"
-            exit 1
+            Write-Host "⚠️ Post deployment script failed with error: $($_.Exception.Message), but pipeline will continue."
           }
 
       - name: Logout from Azure


### PR DESCRIPTION
## Purpose
This pull request makes the CI pipeline more resilient by allowing failures in the post deployment script to not halt the entire pipeline. The key changes are in the error handling logic for the post deployment step in `.github/workflows/CI.yml`.

CI/CD Pipeline Resilience:

* Added `continue-on-error: true` to the "Run Post Deployment Script" step, so failures in this step will not stop the workflow.
* Modified error and exit code handling messages to indicate that failures will not halt the pipeline, replacing exit statements with warnings.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
