### PR TITLE
fix: Added a fallback mechanism in `Deployment/resourcedeployment.ps1` so that if deployment is not available, resource names and properties are reconstructed using the `SolutionSuffix` tag

### DIFF
--- a/Deployment/resourcedeployment.ps1
+++ b/Deployment/resourcedeployment.ps1
@@ -496,13 +496,10 @@ class DeploymentResult {
             $this.AzAppConfigEndpoint = "https://$($this.AzAppConfigName).azconfig.io"
 
             # Get AKS managed identity
-            $aksMid = az aks show --name $this.AksName --resource-group $resourceGroupName --query "identity.principalId" -o tsv 2>$null
-            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($aksMid)) {
+            $this.AksMid = az aks show --name $this.AksName --resource-group $resourceGroupName --query "identity.principalId" -o tsv 2>$null
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($this.AksMid)) {
                 Write-Host "Warning: Failed to retrieve AKS managed identity for '$($this.AksName)' in resource group '$resourceGroupName'.`n`tThe AKS cluster may not exist or you may not have sufficient permissions." -ForegroundColor Yellow
                 $this.AksMid = $null
-            }
-            else {
-                $this.AksMid = $aksMid
             }
 
             Write-Host "Successfully reconstructed resource names from SolutionSuffix '$solutionSuffix'" -ForegroundColor Green

--- a/Deployment/resourcedeployment.ps1
+++ b/Deployment/resourcedeployment.ps1
@@ -362,91 +362,148 @@ class DeploymentResult {
     }
 
     [void]MapResultAz([string]$resourceGroupName) {
-        # Get deployment outputs
-        $deploymentName=$(az group show --name "$resourceGroupName" --query "tags.DeploymentName" -o tsv)
-        if (!$deploymentName) {
-            Write-Error "Deployment name not found in the resource group tags."
-            exit 1
-        }
-    
-        $deploymentOutputs=$(az deployment group show --resource-group "$resourceGroupName" --name "$deploymentName" --query "properties.outputs" -o json | ConvertFrom-Json)
-    
-        # Helper function to get value from deployment outputs with fallback
-        function Get-DeploymentOutputValue {
-            param (
-                [Parameter(Mandatory=$true)]
-                $outputs,
-                [Parameter(Mandatory=$true)]
-                [string]$primaryKey,
-                [Parameter(Mandatory=$true)]
-                [string]$fallbackKey
-            )
+        try {
+            Write-Host "Retrieving resource group tags..." -ForegroundColor Yellow
             
-            $value = $null
+            # Get deployment name from tags
+            $deploymentName = az group show --name $resourceGroupName --query "tags.DeploymentName" -o tsv 2>$null
             
-            # Try primary key first (old convention)
-            if ($outputs.PSObject.Properties.Name -contains $primaryKey) {
-                $value = $outputs.$primaryKey.value
+            if ([string]::IsNullOrEmpty($deploymentName)) {
+                Write-Host "DeploymentName tag not found. Using SolutionSuffix fallback..." -ForegroundColor Yellow
             }
-            
-            # If not found or empty, try fallback key (new convention)
-            if ([string]::IsNullOrEmpty($value) -and ($outputs.PSObject.Properties.Name -contains $fallbackKey)) {
-                $value = $outputs.$fallbackKey.value
+            else {
+                Write-Host "Found deployment name from tag: $deploymentName" -ForegroundColor Green
+                
+                # Check if deployment exists
+                $deploymentState = az deployment group show `
+                    --resource-group $resourceGroupName `
+                    --name $deploymentName `
+                    --query "properties.provisioningState" `
+                    -o tsv 2>$null
+                
+                if ($deploymentState -eq "Succeeded") {
+                    Write-Host "Deployment exists and succeeded. Retrieving outputs..." -ForegroundColor Green
+
+                    # Get deployment outputs
+                    $deploymentOutputs = az deployment group show `
+                        --resource-group $resourceGroupName `
+                        --name $deploymentName `
+                        --query "properties.outputs" `
+                        -o json | ConvertFrom-Json
+
+                    # Helper function to get value from deployment outputs with fallback
+                    function Get-DeploymentOutputValue {
+                        param (
+                            [Parameter(Mandatory=$true)]
+                            $outputs,
+                            [Parameter(Mandatory=$true)]
+                            [string]$primaryKey,
+                            [Parameter(Mandatory=$true)]
+                            [string]$fallbackKey
+                        )
+
+                        $value = $null
+
+                        # Try primary key first
+                        if ($outputs.PSObject.Properties.Name -contains $primaryKey) {
+                            $value = $outputs.$primaryKey.value
+                        }
+
+                        # If not found or empty, try fallback key
+                        if ([string]::IsNullOrEmpty($value) -and ($outputs.PSObject.Properties.Name -contains $fallbackKey)) {
+                            $value = $outputs.$fallbackKey.value
+                        }
+
+                        return $value
+                    }
+
+                    # Map all outputs to properties
+                    $this.TenantId = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_TENANT_ID" -fallbackKey "azureTenantId"
+                    if ([string]::IsNullOrEmpty($this.TenantId)) {
+                        $this.TenantId = az account show --query tenantId -o tsv
+                    }
+
+                    $this.SubscriptionId = az account show --query id -o tsv
+                    $this.ResourceGroupName = $resourceGroupName
+                    $this.ResourceGroupId = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_RESOURCE_GROUP_ID" -fallbackKey "azureResourceGroupId"
+
+                    $this.StorageAccountName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "storagE_ACCOUNT_NAME" -fallbackKey "storageAccountName"
+                    $this.AzSearchServiceName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_SEARCH_SERVICE_NAME" -fallbackKey "azureSearchServiceName"
+                    $this.AzSearchServicEndpoint = "https://$($this.AzSearchServiceName).search.windows.net"
+
+                    $this.AksName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_AKS_NAME" -fallbackKey "azureAksName"
+                    $this.AksMid = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_AKS_MI_ID" -fallbackKey "azureAksMiId"
+
+                    $this.AzContainerRegistryName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_CONTAINER_REGISTRY_NAME" -fallbackKey "azureContainerRegistryName"
+                    $this.AzCognitiveServiceName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_COGNITIVE_SERVICE_NAME" -fallbackKey "azureCognitiveServiceName"
+                    $this.AzCognitiveServiceEndpoint = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_COGNITIVE_SERVICE_ENDPOINT" -fallbackKey "azureCognitiveServiceEndpoint"
+                    $this.AzOpenAiServiceName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_OPENAI_SERVICE_NAME" -fallbackKey "azureOpenAiServiceName"
+                    $this.AzOpenAiServiceEndpoint = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_OPENAI_SERVICE_ENDPOINT" -fallbackKey "azureOpenAiServiceEndpoint"
+
+                    $this.AzCosmosDBName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_COSMOSDB_NAME" -fallbackKey "azureCosmosDbName"
+                    $this.AzGPT4oModelName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "aZ_GPT4O_MODEL_NAME" -fallbackKey "azGpt4oModelName"
+                    $this.AzGPT4oModelId = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "aZ_GPT4O_MODEL_ID" -fallbackKey "azGpt4oModelId"
+                    $this.AzGPTEmbeddingModelName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "aZ_GPT_EMBEDDING_MODEL_NAME" -fallbackKey "azGptEmbeddingModelName"
+                    $this.AzGPTEmbeddingModelId = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "aZ_GPT_EMBEDDING_MODEL_ID" -fallbackKey "azGptEmbeddingModelId"
+
+                    $this.AzAppConfigEndpoint = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_APP_CONFIG_ENDPOINT" -fallbackKey "azureAppConfigEndpoint"
+                    $this.AzAppConfigName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_APP_CONFIG_NAME" -fallbackKey "azureAppConfigName"
+
+                    Write-Host "Successfully retrieved deployment outputs" -ForegroundColor Green
+                    return
+                }
+                else {
+                    Write-Host "Deployment '$deploymentName' not found or did not succeed. Using SolutionSuffix fallback..." -ForegroundColor Yellow
+                }
             }
-            
-            return $value
+
+            # FALLBACK: Use SolutionSuffix from tags
+            Write-Host "Attempting to use SolutionSuffix fallback mechanism..." -ForegroundColor Yellow
+            $solutionSuffix = az group show --name $resourceGroupName --query "tags.SolutionSuffix" -o tsv 2>$null
+
+            if ([string]::IsNullOrEmpty($solutionSuffix)) {
+                throw "Cannot proceed: Neither deployment outputs nor SolutionSuffix tag found in resource group '$resourceGroupName'"
+            }
+
+            Write-Host "Found SolutionSuffix from tags: $solutionSuffix" -ForegroundColor Green
+
+            # Basic properties
+            $this.TenantId = az account show --query tenantId -o tsv
+            $this.SubscriptionId = az account show --query id -o tsv
+            $this.ResourceGroupName = $resourceGroupName
+            $this.ResourceGroupId = az group show --name $resourceGroupName --query id -o tsv
+
+            # Reconstruct resource names using same pattern as main.bicep
+            $this.StorageAccountName = "st$solutionSuffix"
+            $this.AzSearchServiceName = "srch-$solutionSuffix"
+            $this.AksName = "aks-$solutionSuffix"
+            $this.AzContainerRegistryName = "cr$($solutionSuffix.Replace('-', ''))"
+            $this.AzCognitiveServiceName = "di-$solutionSuffix"
+            $this.AzOpenAiServiceName = "oai-$solutionSuffix"
+            $this.AzCosmosDBName = "cosmos-$solutionSuffix"
+            $this.AzAppConfigName = "appcs-$solutionSuffix"
+
+            # Model names from bicep defaults
+            $this.AzGPT4oModelName = "gpt-4.1-mini"
+            $this.AzGPT4oModelId = "gpt-4.1-mini"
+            $this.AzGPTEmbeddingModelName = "text-embedding-3-large"
+            $this.AzGPTEmbeddingModelId = "text-embedding-3-large"
+
+            # Construct endpoints
+            $this.AzCognitiveServiceEndpoint = "https://$($this.AzCognitiveServiceName).cognitiveservices.azure.com/"
+            $this.AzOpenAiServiceEndpoint = "https://$($this.AzOpenAiServiceName).openai.azure.com/"
+            $this.AzSearchServicEndpoint = "https://$($this.AzSearchServiceName).search.windows.net"
+            $this.AzAppConfigEndpoint = "https://$($this.AzAppConfigName).azconfig.io"
+
+            # Get AKS managed identity
+            $this.AksMid = az aks show --name $this.AksName --resource-group $resourceGroupName --query "identity.principalId" -o tsv 2>$null
+
+            Write-Host "Successfully reconstructed resource names from SolutionSuffix '$solutionSuffix'" -ForegroundColor Green
         }
-    
-        # Tenant ID
-        $this.TenantId = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_TENANT_ID" -fallbackKey "azureTenantId"
-        if (!$this.TenantId) {
-            $this.TenantId = $(az account show --query tenantId -o tsv)
+        catch {
+            Write-Host "Error in MapResultAz: $_" -ForegroundColor Red
+            throw
         }
-    
-        $this.SubscriptionId = $(az account show --query id -o tsv)
-    
-        # Resource Group
-        $this.ResourceGroupName = $resourceGroupName
-        $this.ResourceGroupId = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_RESOURCE_GROUP_ID" -fallbackKey "azureResourceGroupId"
-        if (!$this.ResourceGroupId) {
-            Write-Error "Required value 'AZURE_RESOURCE_GROUP_ID' or 'azureResourceGroupId' not found in the deployment outputs."
-            exit 1
-        }
-    
-        # Storage Account
-        $this.StorageAccountName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "storagE_ACCOUNT_NAME" -fallbackKey "storageAccountName"
-    
-        # Search Service
-        $this.AzSearchServiceName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_SEARCH_SERVICE_NAME" -fallbackKey "azureSearchServiceName"
-        $this.AzSearchServicEndpoint = "https://$($this.AzSearchServiceName).search.windows.net"
-    
-        # AKS
-        $this.AksName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_AKS_NAME" -fallbackKey "azureAksName"
-        $this.AksMid = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_AKS_MI_ID" -fallbackKey "azureAksMiId"
-    
-        # Container Registry
-        $this.AzContainerRegistryName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_CONTAINER_REGISTRY_NAME" -fallbackKey "azureContainerRegistryName"
-    
-        # Cognitive Service - Azure AI Document Intelligence Service
-        $this.AzCognitiveServiceName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_COGNITIVE_SERVICE_NAME" -fallbackKey "azureCognitiveServiceName"
-        $this.AzCognitiveServiceEndpoint = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_COGNITIVE_SERVICE_ENDPOINT" -fallbackKey "azureCognitiveServiceEndpoint"
-    
-        # Open AI Service
-        $this.AzOpenAiServiceName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_OPENAI_SERVICE_NAME" -fallbackKey "azureOpenAiServiceName"
-        $this.AzOpenAiServiceEndpoint = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_OPENAI_SERVICE_ENDPOINT" -fallbackKey "azureOpenAiServiceEndpoint"
-    
-        # Cosmos DB
-        $this.AzCosmosDBName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_COSMOSDB_NAME" -fallbackKey "azureCosmosDbName"
-    
-        # Open AI Service Models
-        $this.AzGPT4oModelName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "aZ_GPT4O_MODEL_NAME" -fallbackKey "azGpt4oModelName"
-        $this.AzGPT4oModelId = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "aZ_GPT4O_MODEL_ID" -fallbackKey "azGpt4oModelId"
-        $this.AzGPTEmbeddingModelName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "aZ_GPT_EMBEDDING_MODEL_NAME" -fallbackKey "azGptEmbeddingModelName"
-        $this.AzGPTEmbeddingModelId = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "aZ_GPT_EMBEDDING_MODEL_ID" -fallbackKey "azGptEmbeddingModelId"
-    
-        # App Configuration
-        $this.AzAppConfigEndpoint = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_APP_CONFIG_ENDPOINT" -fallbackKey "azureAppConfigEndpoint"
-        $this.AzAppConfigName = Get-DeploymentOutputValue -outputs $deploymentOutputs -primaryKey "azurE_APP_CONFIG_NAME" -fallbackKey "azureAppConfigName"
     }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -117,6 +117,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
       Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
       CreatedBy: createdBy
       DeploymentName: deployment().name
+      SolutionSuffix: solutionSuffix
     }
   }
 }

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.177.2456",
-      "templateHash": "16347082498493141517"
+      "version": "0.39.26.7824",
+      "templateHash": "14225007957782613645"
     }
   },
   "parameters": {
@@ -299,7 +299,7 @@
       "apiVersion": "2021-04-01",
       "name": "default",
       "properties": {
-        "tags": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags'), createObject('TemplateName', 'DKM', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name)))]"
+        "tags": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags'), createObject('TemplateName', 'DKM', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name, 'SolutionSuffix', variables('solutionSuffix'))))]"
       }
     },
     "avmPrivateDnsZones": {
@@ -311,7 +311,7 @@
       },
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('dns-zone-{0}', copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -3478,7 +3478,7 @@
     "logAnalyticsWorkspace": {
       "condition": "[and(parameters('enableMonitoring'), not(variables('useExistingLogAnalytics')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.operational-insights.workspace.{0}', variables('logAnalyticsWorkspaceResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -6584,7 +6584,7 @@
     "virtualNetwork": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('module.virtualNetwork.{0}', variables('solutionSuffix')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -6621,8 +6621,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.177.2456",
-              "templateHash": "7116469417351280182"
+              "version": "0.39.26.7824",
+              "templateHash": "13170181033896143010"
             }
           },
           "definitions": {
@@ -7041,7 +7041,7 @@
               },
               "condition": "[not(empty(tryGet(parameters('subnets')[copyIndex()], 'networkSecurityGroup')))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('avm.res.network.network-security-group.{0}.{1}', tryGet(parameters('subnets')[copyIndex()], 'networkSecurityGroup', 'name'), parameters('resourceSuffix')), 64)]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -7693,7 +7693,7 @@
             },
             "virtualNetwork": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[take(format('avm.res.network.virtual-network.{0}', parameters('name')), 64)]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -9424,7 +9424,7 @@
     "bastionHost": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.network.bastion-host.{0}', variables('bastionHostName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -10743,7 +10743,7 @@
     "jumpboxVM": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.compute.virtual-machine.{0}', variables('jumpboxVmName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -19086,7 +19086,7 @@
     },
     "userAssignedIdentity": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.managed-identity.user-assigned-identity.{0}', variables('userAssignedIdentityResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -19568,7 +19568,7 @@
     },
     "avmContainerRegistry": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('avmContainerRegistry-{0}', uniqueString('avmContainerRegistry', deployment().name))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -19611,8 +19611,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.177.2456",
-              "templateHash": "11092248228709008584"
+              "version": "0.39.26.7824",
+              "templateHash": "13930413566901114787"
             },
             "name": "Container Registry Module"
           },
@@ -19748,7 +19748,7 @@
           "resources": {
             "avmContainerRegistry": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "[parameters('acrName')]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -22817,7 +22817,7 @@
     },
     "avmCosmosDB": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.cosmos-{0}', variables('solutionSuffix')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -26651,7 +26651,7 @@
     },
     "avmAppConfig": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.app-configuration.configuration-store.{0}', variables('appConfigName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -26723,7 +26723,7 @@
               },
               {
                 "name": "Application:Services:PersistentStorage:CosmosMongo:ConnectionString",
-                "value": "[listOutputsWithSecureValues('avmCosmosDB', '2022-09-01').primaryReadWriteConnectionString]"
+                "value": "[listOutputsWithSecureValues('avmCosmosDB', '2025-04-01').primaryReadWriteConnectionString]"
               },
               {
                 "name": "Application:Services:AzureAISearch:Endpoint",
@@ -28780,7 +28780,7 @@
     "avmAppConfigUpdated": {
       "condition": "[parameters('enablePrivateNetworking')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.app-configuration.configuration-store-update.{0}', variables('appConfigName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -30795,7 +30795,7 @@
     },
     "avmStorageAccount": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.storage.storage-account.{0}', variables('storageAccountName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -36552,15 +36552,15 @@
         }
       },
       "dependsOn": [
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "userAssignedIdentity",
         "virtualNetwork"
       ]
     },
     "avmSearchSearchServices": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.cognitive-search-services.{0}', variables('aiSearchName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -38912,7 +38912,7 @@
     },
     "avmOpenAi": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.cognitiveservices.account.{0}', variables('openAiAccountName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -41511,7 +41511,7 @@
     },
     "documentIntelligence": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.cognitiveservices.account.{0}', variables('docIntelAccountName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -44099,7 +44099,7 @@
     },
     "managedCluster": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.container-service.managed-cluster.aks-{0}', variables('solutionSuffix')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -47436,7 +47436,7 @@
     "applicationInsights": {
       "condition": "[parameters('enableMonitoring')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[take(format('avm.res.insights.component.{0}', variables('applicationInsightsResourceName')), 64)]",
       "properties": {
         "expressionEvaluationOptions": {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Added a fallback mechanism in `Deployment/resourcedeployment.ps1` so that if deployment is not available, resource names and properties are reconstructed using the `SolutionSuffix` tag. 

This pull request introduces improvements to the deployment resource mapping logic and updates the infrastructure templates for better reliability and compatibility. The most significant changes are the enhancement of the fallback mechanism in the deployment result mapping script, the addition of a new tag for resource group identification, and updates to the ARM template API versions.

**Deployment script improvements:**

* Enhanced the `MapResultAz` method in `Deployment/resourcedeployment.ps1` to add robust error handling and a fallback mechanism: if deployment outputs are not available, the script now reconstructs resource names and endpoints using the `SolutionSuffix` tag, ensuring deployments can still be mapped even if outputs are missing. [[1]](diffhunk://#diff-8efa90352de03fa0a511a5c08f49e4c1ba0224d16bf6facaf7c7ba90524edddbL365-R392) [[2]](diffhunk://#diff-8efa90352de03fa0a511a5c08f49e4c1ba0224d16bf6facaf7c7ba90524edddbL387-R506)

**Infrastructure template updates:**

* Added a `SolutionSuffix` tag to the resource group in both `infra/main.bicep` and `infra/main.json`, enabling the fallback mechanism in the deployment script and improving resource identification. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R120) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L302-R302)
* Updated the Bicep-generated ARM templates (`infra/main.json`) to use a newer Bicep version and changed the `apiVersion` for multiple `Microsoft.Resources/deployments` resources from `2022-09-01` to `2025-04-01`, ensuring compatibility with the latest Azure features and APIs. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L314-R314) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3481-R3481) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L6587-R6587) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L7044-R7044) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L7696-R7696) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L9427-R9427) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L10746-R10746) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L19089-R19089) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L19571-R19571) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L19751-R19751) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L22820-R22820) [[13]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L26654-R26654) [[14]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L28783-R28783) [[15]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L30798-R30798)
* Updated references to output values in `infra/main.json` to use the new API version in the `listOutputsWithSecureValues` function for Cosmos DB connection strings.

**Template metadata:**

* Updated the Bicep template generator version and template hash in `infra/main.json` to reflect the new Bicep version. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L6624-R6625) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L19614-R19615)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
