### PR TITLE
fix: add bicep version requirement (>= 0.33.0) to azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -4,6 +4,7 @@ name: document-knowledge-mining-solution-accelerator
 
 requiredVersions:
   azd: '>= 1.18.0 != 1.23.9'
+  bicep: '>= 0.33.0'
 
 # metadata:
 #   template: document-knowledge-mining-solution-accelerator@1.0


### PR DESCRIPTION
## Summary\n\nAdds `bicep: '>= 0.33.0'` to the `requiredVersions` section in `azure.yaml`.\n\nThis ensures the correct Bicep CLI version is used during `azd` deployments.\n\n## Changes\n- Added `bicep: '>= 0.33.0'` under `requiredVersions` in `azure.yaml`