### PR TITLE
docs: use relative path for re-use-log-analytics link

### DIFF
--- a/docs/CustomizingAzdParameters.md
+++ b/docs/CustomizingAzdParameters.md
@@ -18,7 +18,7 @@ By default this template will use the environment name as the prefix to prevent 
 | `AZURE_ENV_EMBEDDING_MODEL_NAME`          | string | `text-embedding-3-large`          | Sets the name of the embedding model to use.                                                |
 | `AZURE_ENV_EMBEDDING_MODEL_VERSION`            | string | `1`          | Version of the embedding model to be used for deployment.                                                   |
 | `AZURE_ENV_EMBEDDING_DEPLOYMENT_CAPACITY`            | int | `100`         | Capacity for embedding model deployment (in thousands of tokens per minute).                                                   |
-| `AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID` | string  | `''` (empty) | Set this if you want to reuse an existing Log Analytics Workspace instead of creating a new one. [Guide to get your Existing Workspace ID](/docs/re-use-log-analytics.md)     |
+| `AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID` | string  | `''` (empty) | Set this if you want to reuse an existing Log Analytics Workspace instead of creating a new one. [Guide to get your Existing Workspace ID](./re-use-log-analytics.md)     |
 | `AZURE_ENV_VM_ADMIN_USERNAME`  | string | `take(newGuid(), 20)`               | The administrator username for the virtual machine.         |
 | `AZURE_ENV_VM_ADMIN_PASSWORD`  | string | `newGuid()`               | The administrator password for the virtual machine.         |
 | `AZURE_ENV_VM_SIZE`            | string | `Standard_D2s_v5`         | The size of the Jumpbox Virtual Machine. Only applicable when `enablePrivateNetworking` is true.  |


### PR DESCRIPTION
Lychee broken-link checker fails on root-relative path '/docs/re-use-log-analytics.md' because no root dir is configured. Switching to a relative link './re-use-log-analytics.md' resolves correctly from docs/CustomizingAzdParameters.md.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
