### PR TITLE
feat: clean up unused Bicep resources (US #41955)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -262,12 +262,40 @@ module logAnalyticsWorkspace 'br/public:avm/res/operational-insights/workspace:0
     // WAF aligned configuration for Private Networking
     publicNetworkAccessForIngestion: enablePrivateNetworking ? 'Disabled' : 'Enabled'
     publicNetworkAccessForQuery: enablePrivateNetworking ? 'Disabled' : 'Enabled'
-    // Note: Windows-specific data sources (WindowsEvent, WindowsPerformanceCounter, IISLogs)
-    // were previously configured here when enablePrivateNetworking=true. They have been removed
-    // because the application workload runs on Linux containers in AKS and does not use IIS.
-    // The only Windows resource is the Jumpbox VM, which does not have the Log Analytics agent
-    // (MMA/AMA) installed and would not emit data to these sources.
-    dataSources: null
+dataSources: enablePrivateNetworking
+      ? [
+          {
+            tags: tags
+            eventLogName: 'Application'
+            eventTypes: [
+              {
+                eventType: 'Error'
+              }
+              {
+                eventType: 'Warning'
+              }
+              {
+                eventType: 'Information'
+              }
+            ]
+            kind: 'WindowsEvent'
+            name: 'applicationEvent'
+          }
+          {
+            counterName: '% Processor Time'
+            instanceName: '*'
+            intervalSeconds: 60
+            kind: 'WindowsPerformanceCounter'
+            name: 'windowsPerfCounter1'
+            objectName: 'Processor'
+          }
+          {
+            kind: 'IISLogs'
+            name: 'sampleIISLog1'
+            state: 'OnPremiseEnabled'
+          }
+        ]
+      : null
   }
 }
 var logAnalyticsWorkspaceResourceId = useExistingLogAnalytics ? existingLogAnalyticsWorkspaceId : logAnalyticsWorkspace!.outputs.resourceId

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -262,7 +262,7 @@ module logAnalyticsWorkspace 'br/public:avm/res/operational-insights/workspace:0
     // WAF aligned configuration for Private Networking
     publicNetworkAccessForIngestion: enablePrivateNetworking ? 'Disabled' : 'Enabled'
     publicNetworkAccessForQuery: enablePrivateNetworking ? 'Disabled' : 'Enabled'
-dataSources: enablePrivateNetworking
+    dataSources: enablePrivateNetworking
       ? [
           {
             tags: tags

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -211,7 +211,6 @@ var privateDnsZones = [
   'privatelink.queue.${environment().suffixes.storage}'
   'privatelink.api.azureml.ms'
   'privatelink.azconfig.io'
-  'privatelink.azurecr.io' // Todo: to be deleted
 ]
 // DNS Zone Index Constants
 var dnsZoneIndex = {
@@ -223,7 +222,6 @@ var dnsZoneIndex = {
   storageQueue: 5
   aiFoundry: 6
   appConfig: 7
-  containerRegistry: 8
 }
 @batchSize(5)
 module avmPrivateDnsZones 'br/public:avm/res/network/private-dns-zone:0.8.1' = [
@@ -264,40 +262,12 @@ module logAnalyticsWorkspace 'br/public:avm/res/operational-insights/workspace:0
     // WAF aligned configuration for Private Networking
     publicNetworkAccessForIngestion: enablePrivateNetworking ? 'Disabled' : 'Enabled'
     publicNetworkAccessForQuery: enablePrivateNetworking ? 'Disabled' : 'Enabled'
-    dataSources: enablePrivateNetworking
-      ? [
-          {
-            tags: tags
-            eventLogName: 'Application'
-            eventTypes: [
-              {
-                eventType: 'Error'
-              }
-              {
-                eventType: 'Warning'
-              }
-              {
-                eventType: 'Information'
-              }
-            ]
-            kind: 'WindowsEvent'
-            name: 'applicationEvent'
-          }
-          {
-            counterName: '% Processor Time'
-            instanceName: '*'
-            intervalSeconds: 60
-            kind: 'WindowsPerformanceCounter'
-            name: 'windowsPerfCounter1'
-            objectName: 'Processor'
-          }
-          {
-            kind: 'IISLogs'
-            name: 'sampleIISLog1'
-            state: 'OnPremiseEnabled'
-          }
-        ]
-      : null
+    // Note: Windows-specific data sources (WindowsEvent, WindowsPerformanceCounter, IISLogs)
+    // were previously configured here when enablePrivateNetworking=true. They have been removed
+    // because the application workload runs on Linux containers in AKS and does not use IIS.
+    // The only Windows resource is the Jumpbox VM, which does not have the Log Analytics agent
+    // (MMA/AMA) installed and would not emit data to these sources.
+    dataSources: null
   }
 }
 var logAnalyticsWorkspaceResourceId = useExistingLogAnalytics ? existingLogAnalyticsWorkspaceId : logAnalyticsWorkspace!.outputs.resourceId
@@ -737,8 +707,12 @@ module avmStorageAccount 'br/public:avm/res/storage/storage-account:0.32.0' = {
       corsRules: []
       deleteRetentionPolicyEnabled: false
       containers: [
+        // 'smemory' is the blob container consumed at runtime by Kernel Memory
+        // (KernelMemory:Services:AzureBlobs:Container in App Configuration). Pre-creating it here
+        // aligns infrastructure-as-code with actual runtime usage. Replaces the legacy 'data'
+        // container, which had no consumer in application code.
         {
-          name: 'data'
+          name: 'smemory'
           publicAccess: 'None'
         }
       ]

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "9394084247445195271"
+      "version": "0.42.1.51946",
+      "templateHash": "3490206552617292915"
     }
   },
   "parameters": {
@@ -268,8 +268,7 @@
       "[format('privatelink.blob.{0}', environment().suffixes.storage)]",
       "[format('privatelink.queue.{0}', environment().suffixes.storage)]",
       "privatelink.api.azureml.ms",
-      "privatelink.azconfig.io",
-      "privatelink.azurecr.io"
+      "privatelink.azconfig.io"
     ],
     "dnsZoneIndex": {
       "cosmosDB": 0,
@@ -279,8 +278,7 @@
       "storageBlob": 4,
       "storageQueue": 5,
       "aiFoundry": 6,
-      "appConfig": 7,
-      "containerRegistry": 8
+      "appConfig": 7
     },
     "logAnalyticsWorkspaceResourceName": "[format('log-{0}', variables('solutionSuffix'))]",
     "bastionHostName": "[format('bas-{0}', variables('solutionSuffix'))]",
@@ -3764,7 +3762,9 @@
           "replication": "[if(parameters('enableRedundancy'), createObject('value', createObject('enabled', true(), 'location', variables('replicaLocation'))), createObject('value', null()))]",
           "publicNetworkAccessForIngestion": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
           "publicNetworkAccessForQuery": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
-          "dataSources": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(createObject('tags', parameters('tags'), 'eventLogName', 'Application', 'eventTypes', createArray(createObject('eventType', 'Error'), createObject('eventType', 'Warning'), createObject('eventType', 'Information')), 'kind', 'WindowsEvent', 'name', 'applicationEvent'), createObject('counterName', '% Processor Time', 'instanceName', '*', 'intervalSeconds', 60, 'kind', 'WindowsPerformanceCounter', 'name', 'windowsPerfCounter1', 'objectName', 'Processor'), createObject('kind', 'IISLogs', 'name', 'sampleIISLog1', 'state', 'OnPremiseEnabled'))), createObject('value', null()))]"
+          "dataSources": {
+            "value": null
+          }
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -6885,8 +6885,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "5508350408852137780"
+              "version": "0.42.1.51946",
+              "templateHash": "8313786962324208054"
             }
           },
           "definitions": {
@@ -7154,20 +7154,6 @@
                     "name": "nsg-peps",
                     "securityRules": []
                   }
-                },
-                {
-                  "name": "deployment-scripts",
-                  "addressPrefixes": [
-                    "10.0.4.0/24"
-                  ],
-                  "networkSecurityGroup": {
-                    "name": "nsg-deployment-scripts",
-                    "securityRules": []
-                  },
-                  "delegation": "Microsoft.ContainerInstance/containerGroups",
-                  "serviceEndpoints": [
-                    "Microsoft.Storage"
-                  ]
                 },
                 {
                   "name": "jumpbox",
@@ -9704,10 +9690,6 @@
             "bastionSubnetResourceId": {
               "type": "string",
               "value": "[if(contains(map(parameters('subnets'), lambda('subnet', lambdaVariables('subnet').name)), 'AzureBastionSubnet'), reference('virtualNetwork').outputs.subnetResourceIds.value[indexOf(map(parameters('subnets'), lambda('subnet', lambdaVariables('subnet').name)), 'AzureBastionSubnet')], '')]"
-            },
-            "deploymentScriptsSubnetResourceId": {
-              "type": "string",
-              "value": "[if(contains(map(parameters('subnets'), lambda('subnet', lambdaVariables('subnet').name)), 'deployment-scripts'), reference('virtualNetwork').outputs.subnetResourceIds.value[indexOf(map(parameters('subnets'), lambda('subnet', lambdaVariables('subnet').name)), 'deployment-scripts')], '')]"
             },
             "jumpboxSubnetResourceId": {
               "type": "string",
@@ -21098,8 +21080,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "16957454238390913514"
+              "version": "0.42.1.51946",
+              "templateHash": "6741936050304509173"
             },
             "name": "Container Registry Module"
           },
@@ -35719,7 +35701,7 @@
               "deleteRetentionPolicyEnabled": false,
               "containers": [
                 {
-                  "name": "data",
+                  "name": "smemory",
                   "publicAccess": "None"
                 }
               ]
@@ -49125,8 +49107,8 @@
       },
       "dependsOn": [
         "avmOpenAi",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "virtualNetwork"
       ]
     },

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "3490206552617292915"
+      "version": "0.43.1.21952",
+      "templateHash": "16210311400744160873"
     }
   },
   "parameters": {
@@ -3762,9 +3762,7 @@
           "replication": "[if(parameters('enableRedundancy'), createObject('value', createObject('enabled', true(), 'location', variables('replicaLocation'))), createObject('value', null()))]",
           "publicNetworkAccessForIngestion": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
           "publicNetworkAccessForQuery": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
-          "dataSources": {
-            "value": null
-          }
+          "dataSources": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(createObject('tags', parameters('tags'), 'eventLogName', 'Application', 'eventTypes', createArray(createObject('eventType', 'Error'), createObject('eventType', 'Warning'), createObject('eventType', 'Information')), 'kind', 'WindowsEvent', 'name', 'applicationEvent'), createObject('counterName', '% Processor Time', 'instanceName', '*', 'intervalSeconds', 60, 'kind', 'WindowsPerformanceCounter', 'name', 'windowsPerfCounter1', 'objectName', 'Processor'), createObject('kind', 'IISLogs', 'name', 'sampleIISLog1', 'state', 'OnPremiseEnabled'))), createObject('value', null()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -6885,8 +6883,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "8313786962324208054"
+              "version": "0.43.1.21952",
+              "templateHash": "10615902090169258577"
             }
           },
           "definitions": {
@@ -21080,8 +21078,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "6741936050304509173"
+              "version": "0.43.1.21952",
+              "templateHash": "2328998422553242639"
             },
             "name": "Container Registry Module"
           },

--- a/infra/modules/virtualNetwork.bicep
+++ b/infra/modules/virtualNetwork.bicep
@@ -84,16 +84,6 @@ param subnets subnetType[] = [
     }
   }
   {
-    name: 'deployment-scripts'
-    addressPrefixes: ['10.0.4.0/24']
-    networkSecurityGroup: {
-      name: 'nsg-deployment-scripts'
-      securityRules: []
-      }
-    delegation: 'Microsoft.ContainerInstance/containerGroups'
-    serviceEndpoints: ['Microsoft.Storage']
-  }
-  {
     name: 'jumpbox'
     addressPrefixes: ['10.0.12.0/23'] // /23 (10.0.12.0 - 10.0.13.255), 512 addresses
     networkSecurityGroup: {
@@ -306,7 +296,6 @@ output subnets subnetOutputType[] = [
 output webSubnetResourceId string = contains(map(subnets, subnet => subnet.name), 'web') ? virtualNetwork.outputs.subnetResourceIds[indexOf(map(subnets, subnet => subnet.name), 'web')] : ''
 output pepsSubnetResourceId string = contains(map(subnets, subnet => subnet.name), 'peps') ? virtualNetwork.outputs.subnetResourceIds[indexOf(map(subnets, subnet => subnet.name), 'peps')] : ''
 output bastionSubnetResourceId string = contains(map(subnets, subnet => subnet.name), 'AzureBastionSubnet') ? virtualNetwork.outputs.subnetResourceIds[indexOf(map(subnets, subnet => subnet.name), 'AzureBastionSubnet')] : ''
-output deploymentScriptsSubnetResourceId string = contains(map(subnets, subnet => subnet.name), 'deployment-scripts') ? virtualNetwork.outputs.subnetResourceIds[indexOf(map(subnets, subnet => subnet.name), 'deployment-scripts')] : ''
 output jumpboxSubnetResourceId string = contains(map(subnets, subnet => subnet.name), 'jumpbox') ? virtualNetwork.outputs.subnetResourceIds[indexOf(map(subnets, subnet => subnet.name), 'jumpbox')] : ''
 
 @export()


### PR DESCRIPTION
Findings addressed:

1. Remove unused 'privatelink.azurecr.io' Private DNS Zone (and dnsZoneIndex.containerRegistry) - ACR has no private endpoint and uses publicNetworkAccess: Enabled.

2. Remove unused 'deployment-scripts' subnet (10.0.4.0/24), its NSG (nsg-deployment-scripts), and the deploymentScriptsSubnetResourceId output - no Microsoft.Resources/deploymentScripts resources exist

3. Replace 'data' blob container with 'smemory' to align IaC with actual runtime usage (KernelMemory:Services:AzureBlobs:Container).

Regenerated infra/main.json via 'az bicep build'.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
