### PR TITLE
docs: Add Bicep CLI (v0.33.0+) to local deployment prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Follow the quick deploy steps on the deployment guide to deploy this solution 
 
 > **Note:** This solution accelerator requires **Azure Developer CLI (azd) version 1.18.0 or higher**. Please ensure you have the latest version installed before proceeding with deployment. [Download azd here](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd).
 
+> **Note:** This solution accelerator also requires **Bicep CLI version 0.33.0 or higher** for compiling infrastructure templates. [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install).
+
 [Click here to launch the deployment guide](./docs/DeploymentGuide.md)
 <br/><br/>
 > **Note**: Some tenants may have additional security restrictions that run periodically and could impact the application (e.g., blocking public network access). If you experience issues or the application stops working, check if these restrictions are the cause. In such cases, consider deploying the WAF-supported version to ensure compliance. To configure, [Click here](./docs/DeploymentGuide.md#31-choose-deployment-type-optional).

--- a/docs/AVMPostDeploymentGuide.md
+++ b/docs/AVMPostDeploymentGuide.md
@@ -40,6 +40,8 @@ Before starting the post-deployment process, ensure you have the following:
 6. **[Docker Desktop](https://docs.docker.com/get-docker/)** - Container platform for building and publishing images
    > ⚠️ **Important**: Ensure Docker Desktop is running before executing the deployment script
 
+7. **[Bicep CLI](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install)** <small>(v0.33.0+)</small> - Required for compiling infrastructure templates
+
 ### Azure Requirements
 
 7. **Azure Access** - One of the following roles on the subscription:

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -82,6 +82,7 @@ Ensure you have access to an [Azure subscription](https://azure.microsoft.com/fr
 - [PowerShell 7.0+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) 
 - [Azure CLI (az) 1.18.0+](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-windows?tabs=azure-cli)
 - [Azure Developer CLI (azd) 1.18.0+](https://aka.ms/install-azd)
+- [Bicep CLI 0.33.0+](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install)
 - [Helm](https://helm.sh/docs/intro/install/)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - [Git](https://git-scm.com/downloads)


### PR DESCRIPTION
## Summary

This PR adds the **Bicep CLI** (`v0.33.0+`) as a prerequisite to the local deployment guide of this Generic Solution Accelerator.

The infrastructure-as-code templates in this repository (under `infra/`) require a recent version of the Bicep CLI to compile and deploy successfully via `azd up` / `az deployment`. Without the minimum supported version, users running the deployment locally encounter cryptic compilation errors due to unsupported syntax/features in older Bicep releases.

## Changes

- Added a Bicep CLI (v0.33.0+) entry to the prerequisites list of the local deployment guide, following the **exact format and style** of the existing prerequisite entries (azd, Python, Node.js, etc.) in this repo.

## Why

- Aligns the local deployment guide with the actual minimum Bicep version required by the Bicep templates in this repository.
- Prevents first-run failures for new users provisioning the accelerator from a fresh local environment.
- Brings this accelerator in line with the standard prerequisite set being rolled out across all CSA Generic Solution Accelerators (GSAs).

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Verified the Markdown renders correctly on GitHub (entry appears in the prerequisites list, link resolves to the official Microsoft Learn install page).
- [x] Confirmed the change is scoped to documentation only — no code, infrastructure, or configuration paths are modified.

## Checklist

- [x] My change follows the existing documentation style and formatting of the repository.
- [x] I have performed a self-review of my changes.
- [x] No new warnings, broken links, or formatting issues are introduced.
- [x] No code, configuration, or behavior changes are included in this PR (docs-only).

## Related Work Item

- AB#42634 — `[ALL GSA's] - Add bicep version to the local deployment guide`
