### PR TITLE
ci: pin third-party GitHub Actions to verified release SHAs

### DIFF
--- a/.github/workflows/broken-links-checker.yml
+++ b/.github/workflows/broken-links-checker.yml
@@ -24,17 +24,24 @@ jobs:
       - name: Get changed markdown files (PR only)
         id: changed-markdown-files
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v46
-        with:
-          files: |
-            **/*.md
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed_files=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- '*.md' | tr '\n' ' ' | sed 's/ *$//')
+          if [ -n "$changed_files" ]; then
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "all_changed_files=$changed_files" >> "$GITHUB_OUTPUT"
 
 
       # For PR: Check broken links only in changed files
       - name: Check Broken Links in Changed Markdown Files
         id: lychee-check-pr
         if: github.event_name == 'pull_request' && steps.changed-markdown-files.outputs.any_changed == 'true'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >
             --verbose --no-progress --exclude ^https?://
@@ -47,7 +54,7 @@ jobs:
       - name: Check Broken Links in All Markdown Files in Entire Repo (Manual Trigger)
         id: lychee-check-manual
         if: github.event_name == 'workflow_dispatch'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >
             --verbose --no-progress --exclude ^https?://

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Pin third-party GitHub Actions to specific release commit SHAs (instead of mutable version tags) for reproducible and immutable workflow runs.
* Replace the `tj-actions/changed-files` action in the broken-link checker with a built-in `git diff` step, which removes a third-party dependency from change detection.

Changes:
* `.github/workflows/broken-links-checker.yml` — replace `tj-actions/changed-files` with a built-in `git diff` step; pin `lycheeverse/lychee-action` to `8646ba3` (v2.8.0).
* `.github/workflows/pr-title-checker.yml` — pin `amannn/action-semantic-pull-request` to `48f2562` (v6.1.1).


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
